### PR TITLE
Add file type and OpenAPI spec validation to file upload

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from src.core.parser import OpenAPIParser
 from src.core.generator import TestGenerator
 from src.config.settings import Settings
+from src.utils.validators import validate_file_type, validate_openapi_spec
 from loguru import logger
 
 class APITestApp:
@@ -58,10 +59,18 @@ class APITestApp:
     def process_file(self, uploaded_file: Any):
         """Process the uploaded OpenAPI file."""
         try:
+            if not validate_file_type(uploaded_file):
+                st.error("Unsupported file type. Please upload a YAML or JSON file.")
+                return
+
             # Parse OpenAPI spec
             parser = OpenAPIParser()
             spec_data = parser.parse(uploaded_file)
-            
+
+            if not validate_openapi_spec(spec_data):
+                st.error("The uploaded file is not a valid OpenAPI specification.")
+                return
+
             # Framework selection
             framework = self.framework_selection()
             

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 streamlit==1.32.0
 pydantic==2.6.1
+pydantic-settings==2.2.1
 python-dotenv==1.0.0
 PyYAML==6.0.1
 loguru==0.7.2


### PR DESCRIPTION
## Summary
Added validation checks to the file upload process to ensure only valid OpenAPI specifications in supported formats are processed.

## Key Changes
- Imported new validation utilities (`validate_file_type` and `validate_openapi_spec`) from `src.utils.validators`
- Added file type validation before parsing to reject unsupported file formats early
- Added OpenAPI specification validation after parsing to ensure the uploaded file is a valid OpenAPI spec
- Both validation failures now display user-friendly error messages via Streamlit
- Added `pydantic-settings==2.2.1` dependency to requirements.txt

## Implementation Details
- File type validation occurs first, preventing unnecessary parsing of invalid formats
- OpenAPI spec validation occurs after parsing, ensuring the parsed data conforms to OpenAPI standards
- Validation failures gracefully return early without proceeding to framework selection
- Error messages are displayed to users through Streamlit's error notification system

https://claude.ai/code/session_01ELjSyJnpcunQ5ixF9f5BZc